### PR TITLE
Don't override Module standard method

### DIFF
--- a/lib/valued.rb
+++ b/lib/valued.rb
@@ -3,12 +3,8 @@ require 'valued/version'
 
 module Valued
   module ClassMethods
-    def self.define_method(attr, klass)
-      klass.class_eval { attr_reader attr }
-    end
-
     def attributes(*attributes)
-      attributes.each { |attr| Valued::ClassMethods.define_method(attr, self) }
+      attributes.each { |attribute| self.class_eval { attr_reader attribute } }
       define_method('_attributes') { attributes }
       private :_attributes
     end

--- a/lib/valued/mutable.rb
+++ b/lib/valued/mutable.rb
@@ -1,13 +1,9 @@
 module Valued
   module Mutable
     module ClassMethods
-      def self.define_method(attr, klass)
-        klass.class_eval { attr_accessor attr }
-      end
-
       def attributes(*attributes)
-        attributes.each do |attr|
-          Valued::Mutable::ClassMethods.define_method(attr, self)
+        attributes.each do |attribute|
+          self.class_eval { attr_accessor attribute }
         end
         define_method('_attributes') { attributes }
         private :_attributes


### PR DESCRIPTION
The method `Module.define_method` is a standard method and should not be overwritten, especially not with modified parameters and other functionality.

This PR fixed it.