### PR TITLE
Add block handling to #to_h for customization of resulting hash

### DIFF
--- a/lib/valued.rb
+++ b/lib/valued.rb
@@ -63,8 +63,15 @@ module Valued
   end
 
   def to_h
-    _attributes.each_with_object({}) do |attribute, hash|
-      hash[attribute] = send(attribute)
+    if block_given?
+      _attributes.each_with_object({}) do |attribute, hash|
+        hash_key, hash_value = yield(attribute, send(attribute))
+        hash[hash_key] = hash_value
+      end
+    else
+      _attributes.each_with_object({}) do |attribute, hash|
+        hash[attribute] = send(attribute)
+      end
     end
   end
 

--- a/lib/valued/mutable.rb
+++ b/lib/valued/mutable.rb
@@ -60,8 +60,15 @@ module Valued
     end
 
     def to_h
-      _attributes.each_with_object({}) do |attribute, hash|
-        hash[attribute] = send(attribute)
+      if block_given?
+        _attributes.each_with_object({}) do |attribute, hash|
+          hash_key, hash_value = yield(attribute, send(attribute))
+          hash[hash_key] = hash_value
+        end
+      else
+        _attributes.each_with_object({}) do |attribute, hash|
+          hash[attribute] = send(attribute)
+        end
       end
     end
 

--- a/spec/valued/shared_examples/valued_shared_examples.rb
+++ b/spec/valued/shared_examples/valued_shared_examples.rb
@@ -148,4 +148,23 @@ RSpec.shared_examples 'a Valued' do |valued_module|
       expect(instance.custom_method).to eq(:custom_method)
     end
   end
+
+  describe '#to_h' do
+    it 'returns the expected hash' do
+      hash = instance.to_h
+      expect(hash).to eq({ amount: 2, unit: 'm' })
+    end
+
+    it 'accepts a block' do
+      hash =
+        instance.to_h do |attribute, value|
+          if attribute == :amount
+            ['AMOUNT_TIMES_10', value * 10]
+          else
+            [attribute, value]
+          end
+        end
+      expect(hash).to eq({ 'AMOUNT_TIMES_10' => 20, :unit => 'm' })
+    end
+  end
 end


### PR DESCRIPTION
Hi,

this proposes a solution to #4.

I have added a block handling to `#to_h` so the outcome of the function can be customized. This is also possible for `OpenStruct`: https://ruby-doc.org/stdlib-2.5.1/libdoc/ostruct/rdoc/OpenStruct.html#method-i-to_h

So, given the example from #4 one could get the desired output by using:

```ruby
    it do
      class Child
        include Valued

        attributes :id
      end

      child = Child.new(id: 10)

      class Parent
        include Valued

        attributes :name, :child
      end

      parent = Parent.new(name: 'Fiona', child: child)

      hash = parent.to_h { |attribute, value| attribute == :child ? [:child, value.to_h] : [attribute, value]  }
      expect(hash).to eq({ name: 'Fiona', child: { id: 10 } })
    end
```

Let me know what you think :slightly_smiling_face: 

Cheers,
Patrick